### PR TITLE
breaking change to dataframe schema API: use dict

### DIFF
--- a/pandera/__init__.py
+++ b/pandera/__init__.py
@@ -1,5 +1,7 @@
 from .pandera import DataFrameSchema, Column, Index, PandasDtype, \
-    SeriesSchema, Validator, validate_input, validate_output
+    SeriesSchema, Check, check_input, check_output
+from .pandera import Bool, DateTime, Category, Float, Int, Object, String, \
+    Timedelta
 
 
 __version__ = "0.0.5"


### PR DESCRIPTION
dataframe schema is now specified with a dictionary
where keys are column names and values are Column objects.
This new API can easily extend to multi-column schema checking
as well as multiindex columns, and even multi-index, multi-column
schema checking.

Renamed the `Validator` class to `Check` for brevity and clarity,
and created a variable name for each PandasDtype at the top
of the pandera namespace