### PR TITLE
Allow for columns to be missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,27 @@ schema_float.validate(df).dtypes
 If you want to coerce all of the columns specified in the `DataFrameSchema`,
 you can specify the `coerce` argument with `DataFrameSchema(..., coerce=True)`.
 
+### Required columns
+
+By default all columns specified in the schema are required, meaning that if a column is missing in the input
+dataframe an exception will be thrown. If you want to make a column optional specify `required=False`
+in the column constructor:
+
+```python
+import pandas as pd
+
+from pandera import Column, DataFrameSchema, Int, String
+
+df = pd.DataFrame({"column2": ["hello", "pandera"]})
+schema = DataFrameSchema({
+    "column1": Column(Int, required=False),
+    "column2": Column(String)
+})
+
+validated_df = schema.validate(df)
+# list(validated_df.columns) == ["column2"]
+
+```
 
 ### `SeriesSchema`
 

--- a/pandera/pandera.py
+++ b/pandera/pandera.py
@@ -302,6 +302,8 @@ class Column(SeriesSchemaBase):
         coerce : bool
             Whether or not to coerce the column to the specified pandas_dtype
             before validation
+        required: bool
+            Whether or not column is allowed to be missing
         """
         super(Column, self).__init__(pandas_dtype, checks, nullable)
         self._name = None

--- a/tests/test_pandera.py
+++ b/tests/test_pandera.py
@@ -255,3 +255,36 @@ def test_coerce_dtype():
         })
         with pytest.raises(ValueError):
             schema.validate(df)
+
+
+def test_required():
+    schema = DataFrameSchema({
+        "col1": Column(Int, required=False),
+        "col2": Column(String)
+    })
+
+    df_ok_1 = pd.DataFrame({
+        "col2": ['hello', 'world']
+    })
+
+    df = schema.validate(df_ok_1)
+    assert isinstance(df, pd.DataFrame)
+    assert len(df.columns) == 1
+    assert set(df.columns) == {"col2"}
+
+    df_ok_2 = pd.DataFrame({
+        "col1": [1, 2],
+        "col2": ['hello', 'world']
+    })
+
+    df = schema.validate(df_ok_2)
+    assert isinstance(df, pd.DataFrame)
+    assert len(df.columns) == 2
+    assert set(df.columns) == {"col1", "col2"}
+
+    df_not_ok = pd.DataFrame({
+        "col1": [1, 2]
+    })
+
+    with pytest.raises(Exception):
+        schema.validate(df_not_ok)


### PR DESCRIPTION
By adding a parameter `required` (default to True for compatiblity), we can avoid raising exceptions for columns that can be optional