### PR TITLE
adds a duplicate value check to SeriesSchema

### DIFF
--- a/tests/test_pandera.py
+++ b/tests/test_pandera.py
@@ -33,6 +33,11 @@ def test_series_schema():
         with pytest.raises(TypeError):
             schema.validate(TypeError)
 
+    non_duplicate_schema = SeriesSchema(
+        PandasDtype.Int, allow_duplicates=False)
+    with pytest.raises(SchemaError):
+        non_duplicate_schema.validate(pd.Series([0,1,2,3,4,1]))
+
 
 def test_vectorized_checks():
     schema = SeriesSchema(


### PR DESCRIPTION
This PR:
- adds `allow_duplicates` flag to SeriesSchemaBase and other dependent classes.
- adds a check for duplicates into SeriesSchemaBase
- adds a unit test to check if this condition passes

I think this addresses issue #12 