### PR TITLE
add series.name to error msg and type check in nullable=false

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# Pycharm settings
+.idea

--- a/pandera/pandera.py
+++ b/pandera/pandera.py
@@ -1,11 +1,11 @@
 """Validate Pandas Data Structures."""
 
 import inspect
-import pandas as pd
 import sys
-import wrapt
-
 from collections import OrderedDict
+
+import pandas as pd
+import wrapt
 from enum import Enum
 
 
@@ -32,7 +32,6 @@ Int = PandasDtype.Int
 Object = PandasDtype.Object
 String = PandasDtype.String
 Timedelta = PandasDtype.Timedelta
-
 
 N_FAILURE_CASES = 10
 
@@ -73,22 +72,22 @@ class Check(object):
 
     def vectorized_error_message(self, parent_schema, index, failure_cases):
         return (
-            "%s failed element-wise validator %d:\n"
-            "%s\nfailure cases:\n%s" %
-            (parent_schema, index,
-             self.error_message,
-             self._format_failure_cases(failure_cases)))
+                "%s failed element-wise validator %d:\n"
+                "%s\nfailure cases:\n%s" %
+                (parent_schema, index,
+                 self.error_message,
+                 self._format_failure_cases(failure_cases)))
 
     def generic_error_message(self, parent_schema, index):
         return "%s failed series validator %d: %s" % \
-            (parent_schema, index, self.error_message)
+               (parent_schema, index, self.error_message)
 
     def _format_failure_cases(self, failure_cases):
         failure_cases = (
             failure_cases.rename("failure_case").reset_index()
-            .groupby("failure_case").index.agg([list, len])
-            .rename(columns={"list": "index", "len": "count"})
-            .sort_values("count", ascending=False)
+                .groupby("failure_case").index.agg([list, len])
+                .rename(columns={"list": "index", "len": "count"})
+                .sort_values("count", ascending=False)
         )
         self.failure_cases = failure_cases
         if self.n_failure_cases is None:
@@ -222,8 +221,10 @@ class SeriesSchemaBase(object):
                 type_val_result = series.dtype == _dtype
                 if not type_val_result:
                     raise SchemaError(
-                        "expected series '%s' to have type %s, got %s and non-nullable series contains null values: %s" %
-                        (series.name, self._pandas_dtype.value, series.dtype, series[nulls].head(N_FAILURE_CASES).to_dict()))
+                        "expected series '%s' to have type %s, got %s and "
+                        "non-nullable series contains null values: %s" %
+                        (series.name, self._pandas_dtype.value, series.dtype,
+                         series[nulls].head(N_FAILURE_CASES).to_dict()))
                 else:
                     raise SchemaError(
                         "non-nullable series '%s' contains null values: %s" %
@@ -297,7 +298,7 @@ class Index(SeriesSchemaBase):
 class Column(SeriesSchemaBase):
 
     def __init__(
-        self, pandas_dtype, checks=None, nullable=False, allow_duplicates=True, coerce=False, required=True
+            self, pandas_dtype, checks=None, nullable=False, allow_duplicates=True, coerce=False, required=True
     ):
         """Initialize column validator object.
 
@@ -369,6 +370,7 @@ def check_input(schema, obj_getter=None):
         first argument of the decorated function
 
     """
+
     @wrapt.decorator
     def _wrapper(fn, instance, args, kwargs):
         args = list(args)
@@ -392,6 +394,7 @@ def check_input(schema, obj_getter=None):
             raise ValueError(
                 "obj_getter is unrecognized type: %s" % type(obj_getter))
         return fn(*args, **kwargs)
+
     return _wrapper
 
 
@@ -415,6 +418,7 @@ def check_output(schema, obj_getter=None):
         to be validated.
 
     """
+
     @wrapt.decorator
     def _wrapper(fn, instance, args, kwargs):
         out = fn(*args, **kwargs)
@@ -428,4 +432,5 @@ def check_output(schema, obj_getter=None):
             obj = out
         schema.validate(obj)
         return out
+
     return _wrapper

--- a/pandera/pandera.py
+++ b/pandera/pandera.py
@@ -215,28 +215,29 @@ class SeriesSchemaBase(object):
                     # in case where dtype is meant to be int, make sure that
                     # casting to int results in the same values.
                     raise SchemaError(
-                        "after dropping null values, expected series values "
-                        "to be int, found: %s" % set(series))
+                        "after dropping null values, expected values in series '%s' "
+                        "to be int, found: %s" % (series.name, set(series)))
         else:
             nulls = series.isnull()
             if nulls.sum() > 0:
                 raise SchemaError(
-                    "non-nullable series contains null values: %s" %
-                    series[nulls].head(N_FAILURE_CASES).to_dict())
+                    "non-nullable series '%s' contains null values: %s" %
+                    (series.name, series[nulls].head(N_FAILURE_CASES).to_dict()))
 
         # Check if the series contains duplicate values
         if not self._allow_duplicates:
             duplicates = series.duplicated()
             if any(duplicates):
                 raise SchemaError(
-                    "series contains duplicate valuesvalues: %s" %
-                    series[duplicates].head(N_FAILURE_CASES).to_dict())
+                    "series '%s' contains duplicate values: %s" %
+                    (series.name, series[duplicates].head(N_FAILURE_CASES).to_dict()))
 
         type_val_result = series.dtype == _dtype
         if not type_val_result:
             raise SchemaError(
                 "expected series '%s' to have type %s, got %s" %
                 (series.name, self._pandas_dtype.value, series.dtype))
+
         check_results = []
         for i, check in enumerate(self._checks):
             check_results.append(check(self, series, i))

--- a/pandera/pandera.py
+++ b/pandera/pandera.py
@@ -220,9 +220,15 @@ class SeriesSchemaBase(object):
         else:
             nulls = series.isnull()
             if nulls.sum() > 0:
-                raise SchemaError(
-                    "non-nullable series '%s' contains null values: %s" %
-                    (series.name, series[nulls].head(N_FAILURE_CASES).to_dict()))
+                type_val_result = series.dtype == _dtype
+                if not type_val_result:
+                    raise SchemaError(
+                        "expected series '%s' to have type %s, got %s and non-nullable series contains null values: %s" %
+                        (series.name, self._pandas_dtype.value, series.dtype, series[nulls].head(N_FAILURE_CASES).to_dict()))
+                else:
+                    raise SchemaError(
+                        "non-nullable series '%s' contains null values: %s" %
+                        (series.name, series[nulls].head(N_FAILURE_CASES).to_dict()))
 
         # Check if the series contains duplicate values
         if not self._allow_duplicates:

--- a/tests/test_pandera.py
+++ b/tests/test_pandera.py
@@ -109,6 +109,9 @@ def test_dataframe_schema():
     with pytest.raises(SchemaError):
         schema.validate(df.assign(a=[-1, -2, -1]))
 
+    # checks if 'a' is converted to float, while schema says int, will a schema error be thrown
+    with pytest.raises(SchemaError):
+        schema.validate(df.assign(a=[1.7, 2.3, 3.1]))
 
 def test_index_schema():
     schema = DataFrameSchema(

--- a/tests/test_pandera.py
+++ b/tests/test_pandera.py
@@ -33,6 +33,11 @@ def test_series_schema():
         with pytest.raises(TypeError):
             schema.validate(TypeError)
 
+    non_duplicate_schema = SeriesSchema(
+        PandasDtype.Int, allow_duplicates=False)
+    with pytest.raises(SchemaError):
+        non_duplicate_schema.validate(pd.Series([0,1,2,3,4,1]))
+
 
 def test_vectorized_checks():
     schema = SeriesSchema(


### PR DESCRIPTION
This PR:
- adds 'series.name' into the exception messages for each exception in _SeriesSchemaBase_  
- when _nullable = False_ checks if the type of the series matches the specified type, and if not it will raise an error which states the type _and_ nullability issues
- adds an additional test for when an int is forced into being set as a float to ensure this case is explicitly tested.
- adds '.idea' files to .gitignore to avoid accidentally committing Pycharm files

For context:
- when a user incorrectly specifies an 'Int' column schema
- but the column actually is a float and is supposed to be a float, e.g. because of some process that introduced nulls
- nullability is defaulted to False
- the null check would return before the type check
- this masks the fact that it was actually user error when mispecifying the type in the schema

This was especially problematic in a large set of transformations with multiple checks for columns of the same name with different types.