### PR TITLE
remove `schema` dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,7 @@
 Validating pandas data structures for people seeking correct things.
 
 A light-weight and flexible validation package for
-[pandas](http://pandas.pydata.org) data structures, built on top of
-[schema](https://github.com/keleshev/schema), a powerful Python data structure
-validation tool. API inspired by [pandas-schema](https://tmiguelt.github.io/PandasSchema)
+[pandas](http://pandas.pydata.org) data structures.
 
 
 ## Why?

--- a/pandera/__init__.py
+++ b/pandera/__init__.py
@@ -1,7 +1,6 @@
 from .pandera import DataFrameSchema, Column, Index, PandasDtype, \
-    SeriesSchema, Check, check_input, check_output
-from .pandera import Bool, DateTime, Category, Float, Int, Object, String, \
-    Timedelta
+    SeriesSchema, SchemaError, Check, check_input, check_output, \
+    Bool, DateTime, Category, Float, Int, Object, String, Timedelta
 
 
 __version__ = "0.1.2"

--- a/pandera/pandera.py
+++ b/pandera/pandera.py
@@ -220,9 +220,8 @@ class SeriesSchemaBase(object):
             nulls = series.isnull()
             if nulls.sum() > 0:
                 raise SchemaError(
-                    "non-nullable series '%s' contains null values: %s" %
-                    (series.name,
-                     series[nulls].head(N_FAILURE_CASES).to_dict())
+                    "non-nullable series contains null values: %s" %
+                    series[nulls].head(N_FAILURE_CASES).to_dict()
                 )
 
         # Check if the series contains duplicate values

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 enum34
 numpy >= 1.9.0
 pandas >= 0.23.0
-schema >= 0.6.8
 wrapt

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ setup(
         "enum34 ; python_version<'3.4'",
         "numpy >= 1.9.0",
         "pandas >= 0.23.0",
-        "schema >= 0.6.8",
         "wrapt",
     ],
 )

--- a/tests/test_pandera.py
+++ b/tests/test_pandera.py
@@ -4,10 +4,9 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from schema import SchemaError
-
 from pandera import Column, DataFrameSchema, Index, PandasDtype, \
-    SeriesSchema, Check, Int, DateTime, String, check_input, check_output
+    SeriesSchema, Check, Int, DateTime, String, check_input, check_output, \
+    SchemaError
 
 
 def test_column():


### PR DESCRIPTION
this diff removes pandera's dependency on the schema
package. The main benefit of this change is to produce
cleaner error messages so that it's easier to see which
part of the code yields a SchemaError