### PR TITLE
fixes the way the series check errors when a user supplies a custom type

### DIFF
--- a/pandera/pandera.py
+++ b/pandera/pandera.py
@@ -212,8 +212,7 @@ class SeriesSchemaBase(object):
         if self._nullable:
             series = series.dropna()
             if (_dtype == Int.value):
-                _dtype = Float.value
-                if (series.astype(_dtype) != series).any():
+                if (series.astype(Float.value) != series).any():
                     # in case where dtype is meant to be int, make sure that
                     # casting to int results in the same values.
                     raise SchemaError(
@@ -249,7 +248,7 @@ class SeriesSchemaBase(object):
         if not type_val_result:
             raise SchemaError(
                 "expected series '%s' to have type %s, got %s" %
-                (series.name, self._pandas_dtype.value, series.dtype))
+                (series.name, _dtype, series.dtype))
 
         check_results = []
         for i, check in enumerate(self._checks):


### PR DESCRIPTION
In this example:
```
import pandas as pd
import numpy as np
from pandera import Column, DataFrameSchema, PandasDtype, SeriesSchema, Check, Int
   
schema = DataFrameSchema(
    {"a": Column("int32",nullable=True)
    })
​
df = pd.DataFrame({
    "a": [1, 2, 1]
})
​
schema.validate(df)
```

Currently when pandera errors it will error as below:
```
...
...
/pandera_dev/pandera/pandera.py in __call__(self, series)
    250             raise SchemaError(
    251                 "expected series '%s' to have type %s, got %s" %
--> 252                 (series.name, self._pandas_dtype.value, series.dtype))
    253 
    254         check_results = []

AttributeError: 'str' object has no attribute 'value'
```

There were actually two bugs that this PR fixes:
- firstly, if a user runs a nullability check on an Int series that doesn't contain any null values, in `if self._nullable`, the Schema Error is not triggered but the `_dtype = Float.value` has been set to Float and this is carried through the other if/else conditions will mask the existence of other type errors, e.g. in `type_val_result = series.dtype == _dtype` the _dtype has been overridden to a float but should be an int. 
- secondly, if a user supplies a custom data type as a string, the ` "expected series '%s' to have type %s, got %s" %` error message will itself fail because a string does not have a value and `self._pandas_dtype.value` would fail and result in the ambiguous error above.

With the changes proposed in this PR:
- the _dtype is not set to float if the nullability check is triggered but doesn't fail.
- the _dtype is returned in the later error message instead of `self._pandas_dtype.value`.

With these changes, the error message for the above example is now correct:
```
...
...
/pandera_dev/pandera/pandera.py in __call__(self, series)
    249             raise SchemaError(
    250                 "expected series '%s' to have type %s, got %s" %
--> 251                 (series.name, _dtype, series.dtype))
    252 
    253         check_results = []

SchemaError: expected series 'a' to have type int32, got int64
```