### PR TITLE
fix the series check errors when a user supplies a custom type

### DIFF
--- a/pandera/pandera.py
+++ b/pandera/pandera.py
@@ -207,11 +207,12 @@ class SeriesSchemaBase(object):
 
     def __call__(self, series):
         """Validate a series."""
-        _dtype = self._pandas_dtype if isinstance(self._pandas_dtype, str) \
-            else self._pandas_dtype.value
+        expected_dtype = _dtype = self._pandas_dtype if \
+            isinstance(self._pandas_dtype, str) else self._pandas_dtype.value
         if self._nullable:
             series = series.dropna()
-            if (_dtype == Int.value):
+            if _dtype in ["int_", "int8", "int16", "int32", "int64", "uint8",
+                          "uint16", "uint32", "uint64"]:
                 _dtype = Float.value
                 if (series.astype(_dtype) != series).any():
                     # in case where dtype is meant to be int, make sure that
@@ -249,7 +250,7 @@ class SeriesSchemaBase(object):
         if not type_val_result:
             raise SchemaError(
                 "expected series '%s' to have type %s, got %s" %
-                (series.name, self._pandas_dtype.value, series.dtype))
+                (series.name, expected_dtype, series.dtype))
 
         check_results = []
         for i, check in enumerate(self._checks):


### PR DESCRIPTION
In this example:
```
import pandas as pd
import numpy as np
from pandera import Column, DataFrameSchema, PandasDtype, SeriesSchema, Check, Int
   
schema = DataFrameSchema(
    {"a": Column("int32",nullable=True)
    })
​
df = pd.DataFrame({
    "a": [1, 2, np.nan]
})
​
schema.validate(df)
```

Currently when pandera errors it will error as below:
```
...
...
/pandera_dev/pandera/pandera.py in __call__(self, series)
    250             raise SchemaError(
    251                 "expected series '%s' to have type %s, got %s" %
--> 252                 (series.name, self._pandas_dtype.value, series.dtype))
    253 
    254         check_results = []

AttributeError: 'str' object has no attribute 'value'
```

There were actually two bugs that this PR fixes:
- firstly, if a user runs a nullability check on a python integer type that isn't an "int64", the float coercion wouldn't happen. By adding all integer options as a list, all python in types are now checked (as is described in the readme).
- secondly, if a user supplies a custom data type as a string, the ` "expected series '%s' to have type %s, got %s" %` error message will itself fail because a string does not have a value and `self._pandas_dtype.value` would fail.

With the changes proposed in this PR:
- the `Int.Value` is replaced by a list of all valid python integer types.
- a variable `expected _dtype` is set at the same time `_dtype` is initialised, and `expected _dtype` is now shown by the type error message.

With these changes, the error message for the above example is now correct:
```
...
...
/pandera_dev/pandera/pandera.py in __call__(self, series)
    249             raise SchemaError(
    250                 "expected series '%s' to have type %s, got %s" %
--> 251                 (series.name, _dtype, series.dtype))
    252 
    253         check_results = []

SchemaError: expected series 'a' to have type int32, got int64
```