### PR TITLE
add strict=True option to DataFrameSchema

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,11 +255,12 @@ schema_float.validate(df).dtypes
 If you want to coerce all of the columns specified in the `DataFrameSchema`,
 you can specify the `coerce` argument with `DataFrameSchema(..., coerce=True)`.
 
-### Required columns
+### Required Columns
 
-By default all columns specified in the schema are required, meaning that if a column is missing in the input
-dataframe an exception will be thrown. If you want to make a column optional specify `required=False`
-in the column constructor:
+By default all columns specified in the schema are required, meaning that if a
+column is missing in the input dataframe an exception will be thrown. If you
+want to make a column optional specify `required=False` in the column
+constructor:
 
 ```python
 import pandas as pd
@@ -275,6 +276,25 @@ schema = DataFrameSchema({
 validated_df = schema.validate(df)
 # list(validated_df.columns) == ["column2"]
 
+```
+
+### Handling of Dataframe Columns not in the Schema
+
+By default, columns that aren't specified in the schema aren't checked. If you
+want to check that the dataframe *only* contains columns in the schema, specify
+`strict=True`:
+
+```python
+import pandas as pd
+from pandera import Column, DataFrameSchema, Int
+
+schema = DataFrameSchema({"column1": Column(Int, nullable=True)},
+                         strict=True)
+df = pd.DataFrame({"column2": [1, 2, 3]})
+
+schema.validate(df)
+
+# SchemaError: column 'column2' not in DataFrameSchema {'column1': <Schema Column: 'None' type=int64>}
 ```
 
 ### `SeriesSchema`

--- a/pandera/pandera.py
+++ b/pandera/pandera.py
@@ -134,7 +134,7 @@ class Check(object):
 class DataFrameSchema(object):
     """A light-weight pandas DataFrame validator."""
 
-    def __init__(self, columns, index=None, transformer=None, coerce=False):
+    def __init__(self, columns, index=None, transformer=None, coerce=False, strict=False):
         """Initialize pandas dataframe schema.
 
         Parameters
@@ -150,13 +150,27 @@ class DataFrameSchema(object):
             columns and return the transformed dataframe object.
         coerce : bool
             whether or not to coerce all of the columns on validation.
+        strict : bool
+            whether or not to accept columns in the dataframe that aren't in the
+            DataFrame Schema.
         """
         self.index = index
         self.columns = columns
         self.transformer = transformer
         self.coerce = coerce
+        self.strict = strict
 
     def validate(self, dataframe):
+        # Check if all columns in the dataframe have a corresponding column in
+        # the DataFrameSchema
+        if self.strict:
+            for column in dataframe:
+                if column not in self.columns:
+                    raise SchemaError(
+                        "column '%s' not in DataFrameSchema %s" %
+                        (column, self.columns)
+                    )
+
         for c, col in self.columns.items():
             if c not in dataframe and col.required:
                 raise SchemaError(

--- a/tests/test_pandera.py
+++ b/tests/test_pandera.py
@@ -112,6 +112,17 @@ def test_dataframe_schema():
     with pytest.raises(SchemaError):
         schema.validate(df.assign(a=[1.7, 2.3, 3.1]))
 
+
+def test_dataframe_schema_strict():
+    # checks if strict=True whether a schema error is raised because 'a' is not
+    # present in the dataframe.
+    schema = DataFrameSchema({"a": Column(Int, nullable=True)},
+                             strict=True)
+    df = pd.DataFrame({"b": [1, 2, 3]})
+    with pytest.raises(SchemaError):
+        schema.validate(df)
+
+
 def test_index_schema():
     schema = DataFrameSchema(
         columns={},


### PR DESCRIPTION
This PR implements issue #28 :
- adds `strict=False` as an argument to the DataFrameSchema object
- adds functionality to the `validate` function so that if `strict=True` each column in the dataframe will be checked if it's been specified in the DataFrameSchema columns
- adds a Unit Test to verify that these conditions are triggered as expected
- updates the documentation
  - I have reformatted the `Required Columns` section to follow PEP8 and be 80 chars long.
  - I've added a new section for this `strict` functionality.