### PR TITLE
add badges to readme and improve pypi info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # pandera
 
 [![Build Status](https://travis-ci.org/cosmicBboy/pandera.svg?branch=master)](https://travis-ci.org/cosmicBboy/pandera)
+[![PyPI version shields.io](https://img.shields.io/pypi/v/pandera.svg)](https://pypi.org/project/pandera/)
+[![PyPI license](https://img.shields.io/pypi/l/pandera.svg)](https://pypi.python.org/pypi/pandera/)
 
 **Supports:** python 2.7, 3.5, 3.6
-
-Validating pandas data structures for people seeking correct things.
 
 A light-weight and flexible validation package for
 [pandas](http://pandas.pydata.org) data structures.

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,16 @@
 from setuptools import setup
 
+with open('README.md') as f:
+    long_description = f.read()
 
 setup(
     name="pandera",
     version="0.1.2",
     author="Niels Bantilan",
     author_email="niels.bantilan@gmail.com",
-    description="A pandas data structure validation library",
+    description = 'A light-weight and flexible validation package for pandas data structures.',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
     url="https://github.com/cosmicBboy/pandera",
     keywords=["pandas", "validation", "data-structures"],
     license="MIT",
@@ -19,4 +23,6 @@ setup(
         "pandas >= 0.23.0",
         "wrapt",
     ],
+    python_requires='>=2.6, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4',
+    platforms='any',
 )


### PR DESCRIPTION
This PR:
- adds additional info to `setup.py` to make pypi more complete/professional
- adds `pypi` and `license` badges to readme

Note that adding:
`python_requires='>=2.6, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4',` in `setup.py` is specifically so that in a future PR the python version support can be included in a badge like this:
![Screenshot 2019-05-18 at 19 45 35](https://user-images.githubusercontent.com/3764091/57974098-ba639380-79aa-11e9-849f-5410fa583cd5.png)