### PR TITLE
add `groupby` and `groups` arg to `Check`

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,12 +471,15 @@ zero_column_1_custom(preprocessed_df)
 
 ### Column Check Groups
 
-Column `Check`s support grouping by a different column into dict where keys
-are the group names and keys are subsets of the `Column` series. Specifying
-`groupby` as a column name, list of column names, or callable changes the
-expected signature of the `Check` function argument to
+`Column` `Check`s support grouping by a different column so that you can make
+assertions about subsets of the `Column` of interest. This changes the function
+signature of the `Check` function so that its input is a dict where keys
+are the group names and keys are subsets of the `Column` series.
+
+Specifying `groupby` as a column name, list of column names, or callable
+changes the expected signature of the `Check` function argument to
 `dict[Any|tuple[Any], Series] -> bool|Series[bool]` where the dict keys are
-the discrete values in the `groupby` columns.
+the discrete keys in the `groupby` columns.
 
 ```python
 import pandas as pd
@@ -486,17 +489,12 @@ from pandera import DataFrameSchema, Column, Check, Bool, Float, Int, String
 
 schema = DataFrameSchema({
     "height_in_feet": Column(Float, [
-        # assert that average height if people in the dataset older than 20
-        # years old is greater than six feet
-        Check(lambda g: g[False].mean() > 6 and g[True].mean() < 6,
-              groupby="age_less_than_20"),
-        # define multiple groupby columns, make an assertion about the total
-        # height of the people below the age of 20 who are female.
-        Check(lambda g: g[(True, "F")].sum() == 9.1,  # 5.1 + 4
+        # groupby as a single column
+        Check(lambda g: g[False].mean() > 6, groupby="age_less_than_20"),
+        # define multiple groupby columns
+        Check(lambda g: g[(True, "F")].sum() == 9.1,
               groupby=["age_less_than_20", "sex"]),
-        # groupby as a more complex function, make an assertion about the
-        # median height of people above the age of 15 who are male.
-        # above the age of 15 in the dataset
+        # groupby as a callable with signature (DataFrame) -> DataFrameGroupBy
         Check(lambda g: g[(False, "M")].median() == 6.75,
               groupby=lambda df: (
                 df

--- a/README.md
+++ b/README.md
@@ -37,18 +37,21 @@ from pandera import Column, DataFrameSchema, Float, Int, String, Check
 
 # validate columns
 schema = DataFrameSchema({
-    "column1": Column(Int, Check(lambda x: 0 <= x <= 10)),
-    "column2": Column(Float, Check(lambda x: x < -1.2)),
+    # the check function expects a series argument and should output a boolean
+    # or a boolean Series.
+    "column1": Column(Int, Check(lambda s: s <= 10)),
+    "column2": Column(Float, Check(lambda s: s < -1.2)),
     # you can provide a list of validators
     "column3": Column(String, [
-        Check(lambda x: x.startswith("value_")),
-        Check(lambda x: len(x.split("_")) == 2)]),
+        Check(lambda s: s.str.startswith("value_")),
+        Check(lambda s: s.str.split("_", expand=True).shape[1] == 2)
+    ]),
 })
 
 # alternatively, you can pass strings representing the legal pandas datatypes:
 # http://pandas.pydata.org/pandas-docs/stable/basics.html#dtypes
 schema = DataFrameSchema({
-    "column1": Column("int64", Check(lambda x: 0 <= x <= 10)),
+    "column1": Column("int64", Check(lambda s: s <= 10)),
     ...
 })
 
@@ -68,6 +71,41 @@ print(validated_df)
 #  3       10    -10.1  value_2
 #  4        9    -20.4  value_1
 ```
+
+
+### Vectorized vs. Element-wise Checks
+
+By default, the functions passed into `Check`s are expected to have the
+following signature: `pd.Series -> bool|pd.Series[bool]`. For the `Check` to
+pass, all of the elements in the boolean series must evaluate to `True`.
+
+If you want to make atomic checks for each element in the Column, then you
+can provide the `element_wise=True` keyword argument:
+
+
+```python
+import pandas as pd
+
+from pandera import Check, Column, DataFrameSchema, Int
+
+schema = DataFrameSchema({
+    "a": Column(Int, [
+        # a vectorized check that returns a bool
+        Check(lambda s: s.mean() > 5, element_wise=False),
+        # a vectorized check that returns a boolean series
+        Check(lambda s: s > 0, element_wise=False),
+        # an element-wise check that returns a bool
+        Check(lambda x: x > 0, element_wise=True),
+    ]),
+})
+
+df = pd.DataFrame({"a": [4, 4, 5, 6, 6, 7, 8, 9]})
+schema.validate(df)
+```
+
+By default `element_wise=False` so that you can take advantage of the speed
+gains provided by the `pandas.Series` API by writing vectorized checks.
+
 
 #### Validating DataFrame Index
 
@@ -318,32 +356,6 @@ schema.validate(pd.Series(["1_foobar", "2_foobar", "3_foobar"]))
 #  dtype: object
 ```
 
-
-### Vectorized Checks
-
-If you need to make basic statistical assertions about a column, or you want
-to take advantage of the speed gains affarded by the pd.Series API, use the
-`element_wise=False` keyword argument. The signature of validators then becomes
-`pd.Series -> bool|pd.Series[bool]`.
-
-```python
-import pandas as pd
-
-from pandera import Check, Column, DataFrameSchema, Int
-
-schema = DataFrameSchema({
-    "a": Column(Int, [
-        # this validator returns a bool
-        Check(lambda s: s.mean() > 5, element_wise=False),
-        # this validator returns a boolean series
-        Check(lambda s: s > 0, element_wise=True)])
-})
-
-df = pd.DataFrame({"a": [4, 4, 5, 6, 6, 7, 8, 9]})
-schema.validate(df)
-```
-
-
 ## Plugging into Existing Workflows
 
 If you have an existing data pipeline that uses pandas data structures, you can
@@ -454,6 +466,64 @@ zero_column_1_arg(preprocessed_df)
 zero_column_1_dict(preprocessed_df)
 zero_column_1_custom(preprocessed_df)
 ```
+
+## Advanced Features
+
+### Column Check Groups
+
+Column `Check`s support grouping by a different column into dict where keys
+are the group names and keys are subsets of the `Column` series. Specifying
+`groupby` as a column name, list of column names, or callable changes the
+expected signature of the `Check` function argument to
+`dict[Any|tuple[Any], Series] -> bool|Series[bool]` where the dict keys are
+the discrete values in the `groupby` columns.
+
+```python
+import pandas as pd
+
+from pandera import DataFrameSchema, Column, Check, Bool, Float, Int, String
+
+
+schema = DataFrameSchema({
+    "height_in_feet": Column(Float, [
+        # assert that average height if people in the dataset older than 20
+        # years old is greater than six feet
+        Check(lambda g: g[False].mean() > 6 and g[True].mean() < 6,
+              groupby="age_less_than_20"),
+        # define multiple groupby columns, make an assertion about the total
+        # height of the people below the age of 20 who are female.
+        Check(lambda g: g[(True, "F")].sum() == 9.1,  # 5.1 + 4
+              groupby=["age_less_than_20", "sex"]),
+        # groupby as a more complex function, make an assertion about the
+        # median height of people above the age of 15 who are male.
+        # above the age of 15 in the dataset
+        Check(lambda g: g[(False, "M")].median() == 6.75,
+              groupby=lambda df: (
+                df
+                .assign(age_less_than_15=lambda d: d["age"] < 15)
+                .groupby(["age_less_than_15", "sex"]))),
+    ]),
+    "age": Column(Int, Check(lambda s: s > 0)),
+    "age_less_than_20": Column(Bool),
+    "sex": Column(String, Check(lambda s: s.isin(["M", "F"])))
+})
+
+df = (
+    pd.DataFrame({
+        "height_in_feet": [6.5, 7, 6.1, 5.1, 4],
+        "age": [25, 30, 21, 18, 13],
+        "sex": ["M", "M", "F", "F", "F"]
+    })
+    .assign(age_less_than_20=lambda x: x["age"] < 20)
+)
+
+schema.validate(df)
+```
+
+In the above example we define a `DataFrameSchema` with column checks for
+`height_in_feet` using a single column, multiple columns, and an more complex
+groupby function that creates a new column `age_less_than_15` on the fly.
+
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -519,7 +519,7 @@ schema.validate(df)
 ```
 
 In the above example we define a `DataFrameSchema` with column checks for
-`height_in_feet` using a single column, multiple columns, and an more complex
+`height_in_feet` using a single column, multiple columns, and a more complex
 groupby function that creates a new column `age_less_than_15` on the fly.
 
 

--- a/pandera/__init__.py
+++ b/pandera/__init__.py
@@ -1,6 +1,7 @@
 from .pandera import DataFrameSchema, Column, Index, PandasDtype, \
-    SeriesSchema, SchemaError, Check, check_input, check_output, \
-    Bool, DateTime, Category, Float, Int, Object, String, Timedelta
+    SeriesSchema, SchemaError, SchemaInitError, Check, check_input, \
+    check_output, Bool, DateTime, Category, Float, Int, Object, String, \
+    Timedelta
 
 
 __version__ = "0.1.2"

--- a/pandera/pandera.py
+++ b/pandera/pandera.py
@@ -155,9 +155,19 @@ class Check(object):
                 pd.concat([series, dataframe], axis=1))[series.name]
         else:
             raise TypeError("Type %s not recognized for `groupby` argument.")
+
+        if self.groups is None:
+            return {g: s for g, s in groupby_obj}
+
+        group_keys = set(g for g, _ in groupby_obj)
+        invalid_groups = [g for g in self.groups if g not in group_keys]
+        if invalid_groups:
+            raise KeyError(
+                "groups %s provided in `groups` argument not a valid group "
+                "key. Valid group keys: %s" % (invalid_groups, group_keys))
         fn_input = {}
         for group, series in groupby_obj:
-            if self.groups is None or group in self.groups:
+            if group in self.groups:
                 fn_input[group] = series
         return fn_input
 

--- a/pandera/pandera.py
+++ b/pandera/pandera.py
@@ -188,10 +188,6 @@ class Check(object):
     def __call__(self, parent_schema, check_index, check_obj):
         _vcheck = partial(
             self._vectorized_series_check, parent_schema, check_index)
-        if self.groupby is not None and not isinstance(parent_schema, Column):
-            raise SchemaError(
-                "Can only use `groupby` with a pandera.Column, found %s" %
-                type(parent_schema))
         if self.element_wise:
             val_result = check_obj.map(self.fn)
             if val_result.all():
@@ -307,6 +303,12 @@ class SeriesSchemaBase(object):
         if isinstance(checks, Check):
             checks = [checks]
         self._checks = checks
+
+        for check in self._checks:
+            if check.groupby is not None and not isinstance(self, Column):
+                raise SchemaInitError(
+                    "Can only use `groupby` with a pandera.Column, found %s" %
+                    type(self))
 
     def __call__(self, series, dataframe=None):
         """Validate a series."""

--- a/tests/test_pandera.py
+++ b/tests/test_pandera.py
@@ -488,3 +488,10 @@ def test_groupby_init_exceptions():
         })
     with pytest.raises(SchemaInitError):
         init_schema_no_groupby_column()
+
+    # can't use groupby argument in SeriesSchema or Index objects
+    for SchemaClass in [SeriesSchema, Index]:
+        with pytest.raises(
+                SchemaInitError,
+                match="^Can only use `groupby` with a pandera.Column, found"):
+            SchemaClass(Int, Check(lambda s: s["bar"] == 1, groupby="foo"))

--- a/tests/test_pandera.py
+++ b/tests/test_pandera.py
@@ -450,15 +450,26 @@ def test_check_groups():
     with pytest.raises(KeyError, match="^'bar'"):
         schema_fail_key_error.validate(df)
 
-    # raise KeyError when the group does not exist in the groupby column
-    schema_fail_nonexistent_key = DataFrameSchema({
+    # raise KeyError when the group does not exist in the groupby column when
+    # referenced in the Check function
+    schema_fail_nonexistent_key_in_fn = DataFrameSchema({
         "col1": Column(Int, [
             Check(lambda s: s["baz"] > 10, groupby="col2", groups=["foo"]),
         ]),
         "col2": Column(String, Check(lambda s: s.isin(["foo", "bar"]))),
     })
     with pytest.raises(KeyError, match="^'baz'"):
-        schema_fail_nonexistent_key.validate(df)
+        schema_fail_nonexistent_key_in_fn.validate(df)
+
+    # raise KeyError when the group does not exist in the groups argument.
+    schema_fail_nonexistent_key_in_groups = DataFrameSchema({
+        "col1": Column(Int, [
+            Check(lambda s: s["foo"] > 10, groupby="col2", groups=["baz"]),
+        ]),
+        "col2": Column(String, Check(lambda s: s.isin(["foo", "bar"]))),
+    })
+    with pytest.raises(KeyError):
+        schema_fail_nonexistent_key_in_groups.validate(df)
 
 
 def test_groupby_init_exceptions():

--- a/tests/test_pandera.py
+++ b/tests/test_pandera.py
@@ -5,13 +5,13 @@ import pandas as pd
 import pytest
 
 from pandera import Column, DataFrameSchema, Index, PandasDtype, \
-    SeriesSchema, Check, Float, Int, DateTime, String, check_input, \
-    check_output, SchemaError
+    SeriesSchema, Check, Bool, Float, Int, DateTime, String, check_input, \
+    check_output, SchemaError, SchemaInitError
 
 
 def test_column():
     schema = DataFrameSchema({
-        "a": Column(PandasDtype.Int, Check(lambda x: x > 0))
+        "a": Column(PandasDtype.Int, Check(lambda x: x > 0, element_wise=True))
     })
     data = pd.DataFrame({"a": [1, 2, 3]})
     assert isinstance(schema.validate(data), pd.DataFrame)
@@ -19,7 +19,7 @@ def test_column():
 
 def test_series_schema():
     schema = SeriesSchema(
-        PandasDtype.Int, Check(lambda x: 0 <= x <= 100))
+        PandasDtype.Int, Check(lambda x: 0 <= x <= 100, element_wise=True))
     validated_series = schema.validate(pd.Series([0, 30, 50, 100]))
     assert isinstance(validated_series, pd.Series)
 
@@ -35,7 +35,7 @@ def test_series_schema():
     non_duplicate_schema = SeriesSchema(
         PandasDtype.Int, allow_duplicates=False)
     with pytest.raises(SchemaError):
-        non_duplicate_schema.validate(pd.Series([0,1,2,3,4,1]))
+        non_duplicate_schema.validate(pd.Series([0, 1, 2, 3, 4, 1]))
 
 
 def test_vectorized_checks():
@@ -53,8 +53,8 @@ def test_vectorized_checks():
 def test_series_schema_multiple_validators():
     schema = SeriesSchema(
         PandasDtype.Int, [
-            Check(lambda x: 0 <= x <= 50),
-            Check(lambda s: (s == 21).any(), element_wise=False)])
+            Check(lambda x: 0 <= x <= 50, element_wise=True),
+            Check(lambda s: (s == 21).any())])
     validated_series = schema.validate(pd.Series([1, 5, 21, 50]))
     assert isinstance(validated_series, pd.Series)
 
@@ -66,24 +66,24 @@ def test_series_schema_multiple_validators():
 def test_dataframe_schema():
     schema = DataFrameSchema(
         {
-            "a": Column(PandasDtype.Int, Check(lambda x: x > 0)),
-            "b": Column(PandasDtype.Float, Check(lambda x: 0 <= x <= 10)),
+            "a": Column(PandasDtype.Int,
+                        Check(lambda x: x > 0, element_wise=True)),
+            "b": Column(PandasDtype.Float,
+                        Check(lambda x: 0 <= x <= 10, element_wise=True)),
             "c": Column(PandasDtype.String,
-                        Check(lambda x: set(x) == {"x", "y", "z"},
-                              element_wise=False)),
+                        Check(lambda x: set(x) == {"x", "y", "z"})),
             "d": Column(PandasDtype.Bool,
-                        Check(lambda x: x.mean() > 0.5,
-                              element_wise=False)),
+                        Check(lambda x: x.mean() > 0.5)),
             "e": Column(PandasDtype.Category,
-                        Check(lambda x: set(x) == {"c1", "c2", "c3"},
-                              element_wise=False)),
+                        Check(lambda x: set(x) == {"c1", "c2", "c3"})),
             "f": Column(PandasDtype.Object,
-                        Check(lambda x: x.isin([(1,), (2,), (3,)]),
-                              element_wise=False)),
+                        Check(lambda x: x.isin([(1,), (2,), (3,)]))),
             "g": Column(PandasDtype.DateTime,
-                        Check(lambda x: x >= pd.Timestamp("2015-01-01"))),
+                        Check(lambda x: x >= pd.Timestamp("2015-01-01"),
+                              element_wise=True)),
             "i": Column(PandasDtype.Timedelta,
-                        Check(lambda x: x < pd.Timedelta(10, unit="D")))
+                        Check(lambda x: x < pd.Timedelta(10, unit="D"),
+                              element_wise=True))
         })
     df = pd.DataFrame({
         "a": [1, 2, 3],
@@ -108,7 +108,8 @@ def test_dataframe_schema():
     with pytest.raises(SchemaError):
         schema.validate(df.assign(a=[-1, -2, -1]))
 
-    # checks if 'a' is converted to float, while schema says int, will a schema error be thrown
+    # checks if 'a' is converted to float, while schema says int, will a schema
+    # error be thrown
     with pytest.raises(SchemaError):
         schema.validate(df.assign(a=[1.7, 2.3, 3.1]))
 
@@ -128,8 +129,8 @@ def test_index_schema():
         columns={},
         index=Index(
             PandasDtype.Int, [
-                Check(lambda x: 1 <= x <= 11),
-                Check(lambda index: index.mean() > 1, element_wise=False)]
+                Check(lambda x: 1 <= x <= 11, element_wise=True),
+                Check(lambda index: index.mean() > 1)]
         ))
     df = pd.DataFrame(index=range(1, 11), dtype="int64")
     assert isinstance(schema.validate(df), pd.DataFrame)
@@ -142,14 +143,17 @@ def test_check_function_decorators():
     in_schema = DataFrameSchema(
         {
             "a": Column(PandasDtype.Int, [
-                Check(lambda x: x >= 1),
-                Check(lambda s: s.mean() > 0, element_wise=False)]),
+                Check(lambda x: x >= 1, element_wise=True),
+                Check(lambda s: s.mean() > 0)]),
             "b": Column(PandasDtype.String,
-                        Check(lambda x: x in ["x", "y", "z"])),
+                        Check(lambda x: x in ["x", "y", "z"],
+                              element_wise=True)),
             "c": Column(PandasDtype.DateTime,
-                        Check(lambda x: pd.Timestamp("2018-01-01") <= x)),
+                        Check(lambda x: pd.Timestamp("2018-01-01") <= x,
+                              element_wise=True)),
             "d": Column(PandasDtype.Float,
-                        Check(lambda x: np.isnan(x) or x < 3),
+                        Check(lambda x: np.isnan(x) or x < 3,
+                              element_wise=True),
                         nullable=True)
         },
         transformer=lambda df: df.assign(e="foo")
@@ -157,9 +161,9 @@ def test_check_function_decorators():
     out_schema = DataFrameSchema(
         {
             "e": Column(PandasDtype.String,
-                        Check(lambda s: s == "foo", element_wise=False)),
+                        Check(lambda s: s == "foo")),
             "f": Column(PandasDtype.String,
-                        Check(lambda x: x in ["a", "b"]))
+                        Check(lambda x: x in ["a", "b"], element_wise=True))
         })
 
     # case 1: simplest path test - df is first argument and function returns
@@ -351,3 +355,136 @@ def test_required():
 
     with pytest.raises(Exception):
         schema.validate(df_not_ok)
+
+
+def test_check_groupby():
+    schema = DataFrameSchema({
+        "col1": Column(Int, [
+            Check(lambda s: s["foo"] > 10, groupby="col2"),
+            Check(lambda s: s["bar"] < 10, groupby=["col2"]),
+            Check(lambda s: s["foo"] > 10,
+                  groupby=lambda df: df.groupby("col2")),
+            Check(lambda s: s["bar"] < 10,
+                  groupby=lambda df: df.groupby("col2"))
+        ]),
+        "col2": Column(String, Check(lambda s: s.isin(["foo", "bar"]))),
+    })
+
+    df_pass = pd.DataFrame({
+        "col1": [7, 8, 9, 11, 12, 13],
+        "col2": ["bar", "bar", "bar", "foo", "foo", "foo"],
+    })
+
+    df = schema.validate(df_pass)
+    assert isinstance(df, pd.DataFrame)
+    assert len(df.columns) == 2
+    assert set(df.columns) == {"col1", "col2"}
+
+    # raise SchemaError when Check fails
+    df_fail_on_bar = pd.DataFrame({
+        "col1": [7, 8, 20, 11, 12, 13],
+        "col2": ["bar", "bar", "bar", "foo", "foo", "foo"],
+    })
+    df_fail_on_foo = pd.DataFrame({
+        "col1": [7, 8, 9, 11, 1, 13],
+        "col2": ["bar", "bar", "bar", "foo", "foo", "foo"],
+    })
+    # raise SchemaError when groupby column doesn't exist
+    df_fail_no_column = pd.DataFrame({
+        "col1": [7, 8, 20, 11, 12, 13],
+    })
+
+    for df in [df_fail_on_bar, df_fail_on_foo, df_fail_no_column]:
+        with pytest.raises(SchemaError):
+            schema.validate(df)
+
+
+def test_check_groupby_multiple_columns():
+    schema = DataFrameSchema({
+        "col1": Column(Int, [
+            Check(lambda s: s[("bar", True)].sum() == 16,  # 7 + 9
+                  groupby=["col2", "col3"]),
+        ]),
+        "col2": Column(String, Check(lambda s: s.isin(["foo", "bar"]))),
+        "col3": Column(Bool),
+    })
+
+    df_pass = pd.DataFrame({
+        "col1": [7, 8, 9, 11, 12, 13],
+        "col2": ["bar", "bar", "bar", "foo", "foo", "foo"],
+        "col3": [True, False, True, False, True, False],
+    })
+
+    df = schema.validate(df_pass)
+    assert isinstance(df, pd.DataFrame)
+    assert len(df.columns) == 3
+    assert set(df.columns) == {"col1", "col2", "col3"}
+
+
+def test_check_groups():
+    schema = DataFrameSchema({
+        "col1": Column(Int, [
+            Check(lambda s: s["foo"] > 10, groupby="col2", groups=["foo"]),
+            Check(lambda s: s["foo"] > 10, groupby="col2", groups="foo"),
+        ]),
+        "col2": Column(String, Check(lambda s: s.isin(["foo", "bar"]))),
+    })
+
+    df = pd.DataFrame({
+        "col1": [7, 8, 9, 11, 12, 13],
+        "col2": ["bar", "bar", "bar", "foo", "foo", "foo"],
+    })
+
+    validated_df = schema.validate(df)
+    assert isinstance(validated_df, pd.DataFrame)
+    assert len(validated_df.columns) == 2
+    assert set(validated_df.columns) == {"col1", "col2"}
+
+    # raise KeyError when groups does not include a particular group name
+    schema_fail_key_error = DataFrameSchema({
+        "col1": Column(Int, [
+            Check(lambda s: s["bar"] > 10, groupby="col2", groups="foo"),
+        ]),
+        "col2": Column(String, Check(lambda s: s.isin(["foo", "bar"]))),
+    })
+    with pytest.raises(KeyError, match="^'bar'"):
+        schema_fail_key_error.validate(df)
+
+    # raise KeyError when the group does not exist in the groupby column
+    schema_fail_nonexistent_key = DataFrameSchema({
+        "col1": Column(Int, [
+            Check(lambda s: s["baz"] > 10, groupby="col2", groups=["foo"]),
+        ]),
+        "col2": Column(String, Check(lambda s: s.isin(["foo", "bar"]))),
+    })
+    with pytest.raises(KeyError, match="^'baz'"):
+        schema_fail_nonexistent_key.validate(df)
+
+
+def test_groupby_init_exceptions():
+    def init_schema_element_wise():
+        DataFrameSchema({
+            "col1": Column(Int, [
+                Check(lambda s: s["foo"] > 10,
+                      element_wise=True,
+                      groupby=["col2"]),
+            ]),
+            "col2": Column(String, Check(lambda s: s.isin(["foo", "bar"]))),
+        })
+
+    # can't use groupby in Checks where element_wise == True
+    with pytest.raises(
+            SchemaInitError,
+            match=r"^Cannot use groupby when element_wise=True."):
+        init_schema_element_wise()
+
+    # raise SchemaInitError even when the schema doesn't specify column key for
+    # groupby column
+    def init_schema_no_groupby_column():
+        DataFrameSchema({
+            "col1": Column(Int, [
+                Check(lambda s: s["foo"] > 10, groupby=["col2"]),
+            ]),
+        })
+    with pytest.raises(SchemaInitError):
+        init_schema_no_groupby_column()


### PR DESCRIPTION
fixes #16.

this diff enables more complex `Column` `Check`s that incorporate
data from other columns in a principled way.

This is done by providing a `groupby` argument, which enables
the user to make assertions about subsets of the column based
on the discrete values in the `groupby` column(s).

This is the first step towards #17.

This diff also changes the default of `element_wise=False`