### PR TITLE
add Hypothesis check class and ttest hypothesis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,6 @@ install:
   - conda info -a
   - conda create -q -n ci-env python=$TRAVIS_PYTHON_VERSION
   - source activate ci-env
-  - pip install pytest
+  - pip install pytest scipy
   - python setup.py install
 script: pytest

--- a/README.md
+++ b/README.md
@@ -553,7 +553,7 @@ schema = DataFrameSchema({
                                               alpha = 0.05
                                              ),
     ]),
-    "sex": Column(String, Check(lambda s: s.isin(["M", "F"])))
+    "sex": Column(String)
 })
 
 schema.validate(df)
@@ -574,7 +574,7 @@ schema = DataFrameSchema({
                    relationship_kwargs={"alpha":0.5}
                   ),
     ]),
-    "sex": Column(String, Check(lambda s: s.isin(["M", "F"])))
+    "sex": Column(String)
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -543,7 +543,6 @@ df = (
         "height_in_feet": [6.5, 7, 6.1, 5.1, 4],
         "sex": ["M", "M", "F", "F", "F"]
     })
-    .assign(age_less_than_20=lambda x: x["age"] < 20)
 )
 
 schema = DataFrameSchema({

--- a/README.md
+++ b/README.md
@@ -548,10 +548,10 @@ df = (
 schema = DataFrameSchema({
     "height_in_feet": Column(Float, [
         Hypothesis.two_sample_ttest(groupby="sex",
-                                              groups=["M", "F"],
-                                              relationship="greater_than",
-                                              alpha = 0.05
-                                             ),
+                                    groups=["M", "F"],
+                                    relationship="greater_than",
+                                    alpha = 0.05
+                                    ),
     ]),
     "sex": Column(String)
 })

--- a/pandera/__init__.py
+++ b/pandera/__init__.py
@@ -1,7 +1,7 @@
 from .pandera import DataFrameSchema, Column, Index, PandasDtype, \
     SeriesSchema, SchemaError, SchemaInitError, Check, check_input, \
     check_output, Bool, DateTime, Category, Float, Int, Object, String, \
-    Timedelta
+    Timedelta, Hypothesis
 
 
 __version__ = "0.1.2"

--- a/pandera/pandera.py
+++ b/pandera/pandera.py
@@ -246,15 +246,37 @@ class Hypothesis(Check):
             return self.relationship(*self.test(*[check_obj.get(g) for g in self.groups]))
 
     @classmethod
-    def two_sample_ttest(cls, groupby, groups, relationship, alpha):
-        # the relationship string arg determines if it's one or two-sided
+    def two_sample_ttest(cls, groupby, groups, relationship, alpha=None, relationship_kwargs={},
+                         equal_var=True, test_kwargs={}):
+        # handle alpha as an argument on it's own or in relationship_kwargs:
+        if alpha is not None:
+            if "alpha" in relationship_kwargs:
+                raise SchemaError(
+                    "it is ambiguous to specify alpha in the function signature"
+                    "and relationship_kwargs"
+                )
+            relationship_kwargs["alpha"] = alpha
+        else:
+            relationship_kwargs=relationship_kwargs
+
+        # handle equal_var as an argument on it's own or in test_kwargs:
+        if equal_var is not None:
+            if "equal_var" in test_kwargs:
+                raise SchemaError(
+                    "equal_var has been set in both the function signature and"
+                    "test_kwargs, it should be specified only once"
+                )
+            test_kwargs["equal_var"] = equal_var
+        else:
+            test_kwargs=test_kwargs
+
         return cls(
             test=stats.ttest_ind,
             relationship=relationship,
             groupby=groupby,
             groups=groups,
-            test_kwargs={"equal_var": True},
-            relationship_kwargs={"alpha": alpha}
+            test_kwargs=test_kwargs,
+            relationship_kwargs=relationship_kwargs
         )
 
 

--- a/pandera/pandera.py
+++ b/pandera/pandera.py
@@ -212,7 +212,7 @@ class Check(object):
 class Hypothesis(Check):
     """ Extends Check to cater for hypotheses validation"""
     def __init__(self, test, relationship, groupby=None, groups=None,
-                 test_kwargs=None, relationship_kwargs=None):
+                 test_kwargs={}, relationship_kwargs={}):
         self.test = partial(test, **test_kwargs)
         self.relationship = partial(self.relationships(relationship),
                                     **relationship_kwargs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ enum34
 numpy >= 1.9.0
 pandas >= 0.23.0
 wrapt
+scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ enum34
 numpy >= 1.9.0
 pandas >= 0.23.0
 wrapt
-scipy
+scipy >= 1.2.0

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         "numpy >= 1.9.0",
         "pandas >= 0.23.0",
         "wrapt",
-        "scipy",
+        "scipy ; python_version<'2.7'",
     ],
     python_requires='>=2.6, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4',
     platforms='any',

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
         "numpy >= 1.9.0",
         "pandas >= 0.23.0",
         "wrapt",
+        "scipy",
     ],
     python_requires='>=2.6, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4',
     platforms='any',

--- a/tests/test_pandera.py
+++ b/tests/test_pandera.py
@@ -3,6 +3,7 @@
 import numpy as np
 import pandas as pd
 import pytest
+import scipy
 
 from pandera import Column, DataFrameSchema, Index, PandasDtype, \
     SeriesSchema, Check, Bool, Float, Int, DateTime, String, check_input, \


### PR DESCRIPTION
This PR implements #17:
- Adds a `Hypothesis` class which extends `check`
- Adds the `ttest` Hypothesis as an example

@cosmicBboy I need to write tests/docs, but wanted to get your view of these changes first.

Here's the example from #17 implemented using this approach: 
```
import pandas as pd
from pandera import Column, DataFrameSchema, Int, Float, Check, Bool, String, Hypothesis

df = (
    pd.DataFrame({
        "height_in_feet": [6.5, 7, 6.1, 5.1, 4],
        "age": [25, 30, 21, 18, 13],
        "sex": ["M", "M", "F", "F", "F"]
    })
    .assign(age_less_than_20=lambda x: x["age"] < 20)
)

schema = DataFrameSchema({
    "height_in_feet": Column(Float, [
        Check(lambda g: g[False].mean() > 6, groupby="age_less_than_20"),
        Check(lambda g: g[(True, "F")].sum() == 9.1,
              groupby=["age_less_than_20", "sex"]),
        # groupby as a callable with signature (DataFrame) -> DataFrameGroupBy
        Check(lambda g: g[(False, "M")].median() == 6.75,
              groupby=lambda df: (
                df
                .assign(age_less_than_15=lambda d: d["age"] < 15)
                .groupby(["age_less_than_15", "sex"]))),
        Hypothesis.two_sample_one_sided_ttest(groupby="sex",
                                              groups=["M", "F"],
                                              relationship="lt",
                                              alpha = 0.6
                                             ),
    ]),
#    "age": Column(Int, Check(lambda s: s > 0)),
    "age_less_than_20": Column(Bool),
    "sex": Column(String, Check(lambda s: s.isin(["M", "F"])))
})

schema.validate(df)
```