### PR TITLE
Feature/py versions as button

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,7 @@
 [![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
 [![Documentation Status](https://readthedocs.org/projects/pandera/badge/?version=latest)](https://pandera.readthedocs.io/en/latest/?badge=latest)
 [![codecov](https://codecov.io/gh/cosmicBboy/pandera/branch/master/graph/badge.svg)](https://codecov.io/gh/cosmicBboy/pandera)
-
-**Supports:** python 2.7, 3.5, 3.6
-
+[![PyPI pyversions](https://img.shields.io/pypi/pyversions/pandera.svg)](https://pypi.python.org/pypi/pandera/
 
 ## Why?
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
 [![Documentation Status](https://readthedocs.org/projects/pandera/badge/?version=latest)](https://pandera.readthedocs.io/en/latest/?badge=latest)
 [![codecov](https://codecov.io/gh/cosmicBboy/pandera/branch/master/graph/badge.svg)](https://codecov.io/gh/cosmicBboy/pandera)
-[![PyPI pyversions](https://img.shields.io/pypi/pyversions/pandera.svg)](https://pypi.python.org/pypi/pandera/
+[![PyPI pyversions](https://img.shields.io/pypi/pyversions/pandera.svg)](https://pypi.python.org/pypi/pandera/)
 
 ## Why?
 

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         'Operating System :: OS Independent',
         'Intended Audience :: Science/Research',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',


### PR DESCRIPTION
Very minor change to resolve #41:
- changes "supports python..." into a button that is powered directly from pypi:

<img width="748" alt="image" src="https://user-images.githubusercontent.com/3764091/59190941-fc30c580-8b75-11e9-8374-1e485e68850b.png">


Note that the button doesn't currently say "2.7" because the metadata from ```setup.py``` is coming from the ```classifiers``` section instead of the ```meta``` section. To fix this I've updated ```classifiers``` so that it reflects the _current_ status of the repo, i.e. that it supports 2.7.

```
classifiers=[
        'Development Status :: 5 - Production/Stable',
        'Operating System :: OS Independent',
        'Intended Audience :: Science/Research',
        'Programming Language :: Python',
        'Programming Language :: Python :: 2.7',
        'Programming Language :: Python :: 3',
        'Programming Language :: Python :: 3.5',
        'Programming Language :: Python :: 3.6',
        'Programming Language :: Python :: 3.7',
        'Topic :: Scientific/Engineering'
        ],
```