### PR TITLE
adds explanatory error message to check decorators and tests

### DIFF
--- a/pandera/pandera.py
+++ b/pandera/pandera.py
@@ -1003,7 +1003,7 @@ def check_input(
                 args[obj_getter] = schema.validate(args[obj_getter])
             except IndexError as e:
                 raise SchemaError(
-                        "error in check decorator of function '%s': the "
+                        "error in check_input decorator of function '%s': the "
                         "index '%s' was supplied to the check but this "
                         "function accepts '%s' arguments, so the maximum "
                         "index is '%s'. The full error is: '%s'" %

--- a/pandera/pandera.py
+++ b/pandera/pandera.py
@@ -1003,7 +1003,21 @@ def check_input(
     def _wrapper(fn, instance, args, kwargs):
         args = list(args)
         if isinstance(obj_getter, int):
-            args[obj_getter] = schema.validate(args[obj_getter])
+            try:
+                args[obj_getter] = schema.validate(args[obj_getter])
+            except IndexError as e:
+                raise SchemaError(
+                        "error in check decorator of function '%s': the "
+                        "index '%s' was supplied to the check but this "
+                        "function accepts '%s' arguments, so the maximum "
+                        "index is '%s'. The full error is: '%s'" %
+                        (fn.__name__,
+                         obj_getter,
+                         len(_get_fn_argnames(fn)),
+                         max(0, len(_get_fn_argnames(fn))-1),
+                         e
+                         )
+                        )
         elif isinstance(obj_getter, str):
             if obj_getter in kwargs:
                 kwargs[obj_getter] = schema.validate(kwargs[obj_getter])

--- a/tests/test_pandera.py
+++ b/tests/test_pandera.py
@@ -256,7 +256,7 @@ def test_check_function_decorator_errors():
 
     with pytest.raises(
             SchemaError,
-            match=r"^error in check decorator of function"
+            match=r"^error in check_input decorator of function"
             ):
         test_incorrect_check_input_index(pd.DataFrame({"column1": [1, 2, 3]})
                                          )

--- a/tests/test_pandera.py
+++ b/tests/test_pandera.py
@@ -230,6 +230,9 @@ def test_check_function_decorators():
 
 
 def test_check_function_decorator_errors():
+    """Test that the check_input and check_output decorators error properly."""
+    # case 1: checks that the input and output decorators error when different
+    # types are passed in and out
     @check_input(DataFrameSchema({"column1": Column(Int)}))
     @check_output(DataFrameSchema({"column2": Column(Float)}))
     def test_func(df):
@@ -244,6 +247,19 @@ def test_check_function_decorator_errors():
             SchemaError,
             match=r"^error in check_output decorator of function"):
         test_func(pd.DataFrame({"column1": [1, 2, 3]}))
+
+    # case 2: check that if the input decorator refers to an index that's not
+    # in the function signature, it will fail in a way that's easy to interpret
+    @check_input(DataFrameSchema({"column1": Column(Int)}), 1)
+    def test_incorrect_check_input_index(df):
+        return df
+
+    with pytest.raises(
+            SchemaError,
+            match=r"^error in check decorator of function"
+            ):
+        test_incorrect_check_input_index(pd.DataFrame({"column1": [1, 2, 3]})
+                                         )
 
 
 def test_check_function_decorator_transform():


### PR DESCRIPTION
This PR:
- adds a detailed explanation when the user specifies an invalid index to a check decorator
- this is particularly useful in a long/complex pipeline undergoing refactoring
 
In this example:
```
import pandas as pd
from pandera import Column, Float, DataFrameSchema, check_input, check_output

df_schema = DataFrameSchema(
        {"a":        Column(Float, nullable=True),
         "b":        Column(Float, nullable=True),
         })

df1 = pd.DataFrame({'a':[1.,2.], 'b':[1.,2.]})
df2 = pd.DataFrame({'a':[1.,2.], 'b':[1.,2.]})

@check_input(df_schema, 2)
@check_output(df_schema)
def testing_func(a,b):
    out = a.append(b)
    return out

testing_func(df1,df2)
```

before PR:
```
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
<ipython-input-2-ddac0478d816> in <module>
     16     return out
     17 
---> 18 testing_func(df1,df2)

/pandera_dev/pandera/pandera.py in _wrapper(fn, instance, args, kwargs)
   1004         args = list(args)
   1005         if isinstance(obj_getter, int):
-> 1006             args[obj_getter] = schema.validate(args[obj_getter])
   1007         elif isinstance(obj_getter, str):
   1008             if obj_getter in kwargs:

IndexError: list index out of range
```

after the PR the error is:
```
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
/pandera_dev/pandera/pandera.py in _wrapper(fn, instance, args, kwargs)
   1006             try:
-> 1007                 args[obj_getter] = schema.validate(args[obj_getter])
   1008             except IndexError as e:

IndexError: list index out of range

During handling of the above exception, another exception occurred:

SchemaError                               Traceback (most recent call last)
<ipython-input-2-ddac0478d816> in <module>
     16     return out
     17 
---> 18 testing_func(df1,df2)

/pandera_dev/pandera/pandera.py in _wrapper(fn, instance, args, kwargs)
   1016                          len(_get_fn_argnames(fn)),
   1017                          max(0, len(_get_fn_argnames(fn))-1),
-> 1018                          e
   1019                          )
   1020                         )

SchemaError: error in check decorator of function 'testing_func': the index '2' was supplied to the check but this function accepts '2' arguments, so the maximum index is '1'. The full error is: 'list index out of range'

```