### PR TITLE
drops python 2.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 dist: xenial
 python:
-  - "2.7"
   - "3.5"
   - "3.6"
   - "3.7"
@@ -9,11 +8,7 @@ install:
   - sudo apt-get update
   # We do this conditionally because it saves us some downloading if the
   # version is the same.
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
-    else
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-    fi
+  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-.PHONY: tests upload-pypi conda-build-27 conda-build-35 conda-build-36 \
-	conda-build-37
+.PHONY: tests upload-pypi conda-build-35 conda-build-36 conda-build-37
 
 tests:
 	pytest
@@ -25,9 +24,6 @@ requirements:
 
 mock-ci-tests:
 	. ./ci_tests.sh
-
-conda-build-27:
-	conda-build --python=2.7 conda.recipe
 
 conda-build-35:
 	conda-build --python=3.5 conda.recipe

--- a/ci_tests.sh
+++ b/ci_tests.sh
@@ -10,7 +10,6 @@ run_ci() {
         conda remove -q -y -n pandera-ci-env-$1 --all
 }
 
-run_ci 2.7
 run_ci 3.5
 run_ci 3.6
 run_ci 3.7

--- a/pandera/__init__.py
+++ b/pandera/__init__.py
@@ -23,4 +23,4 @@ from .pandera import (
     )
 
 
-__version__ = "0.1.5"
+__version__ = "0.2.0"

--- a/pandera/pandera.py
+++ b/pandera/pandera.py
@@ -954,10 +954,7 @@ class Column(SeriesSchemaBase):
 
 
 def _get_fn_argnames(fn):
-    if sys.version_info.major >= 3:
-        arg_spec_args = inspect.getfullargspec(fn).args
-    else:
-        arg_spec_args = inspect.getargspec(fn).args
+    arg_spec_args = inspect.getfullargspec(fn).args
 
     if inspect.ismethod(fn) and arg_spec_args[0] == "self":
         # don't include "self" argument

--- a/pandera/pandera.py
+++ b/pandera/pandera.py
@@ -1,7 +1,6 @@
 """Validate Pandas Data Structures."""
 
 import inspect
-import sys
 import warnings
 import pandas as pd
 import wrapt

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,9 @@ from setuptools import setup
 
 with open('README.md') as f:
     long_description = f.read()
-
 setup(
     name="pandera",
-    version="0.1.5",
+    version="0.2.0",
     author="Niels Bantilan",
     author_email="niels.bantilan@gmail.com",
     description="A light-weight and flexible validation package for pandas "
@@ -23,20 +22,18 @@ setup(
         "pandera",
     ],
     install_requires=[
-        "enum34 ; python_version<'3.4'",
         "numpy >= 1.9.0",
         "pandas >= 0.23.0",
         "wrapt",
-        "scipy ; python_version<'2.7'",
+        "scipy ; python_version>='3.5'",
     ],
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+    python_requires='>=3.5',
     platforms='any',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Operating System :: OS Independent',
         'Intended Audience :: Science/Research',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
@@ -45,3 +42,4 @@ setup(
         ],
 
 )
+


### PR DESCRIPTION
This PR:
- removes Python 2.7 from the Travis CI processes
- removes 2.7 support from the makefile and shell scripts
- bumps pandera to 0.2.0 and removes a number of the 2.7-related dependencies in setup.py

Closes #46